### PR TITLE
feat(client): make ApplyTemporaryToken configurable in client options

### DIFF
--- a/promptpal/client.go
+++ b/promptpal/client.go
@@ -32,7 +32,7 @@ type ApplyTemporaryTokenResult struct {
 
 type PromptPalClientOptions struct {
 	Timeout             *time.Duration
-	applyTemporaryToken *func(ctx context.Context) (ApplyTemporaryTokenResult, error)
+	ApplyTemporaryToken *func(ctx context.Context) (ApplyTemporaryTokenResult, error)
 }
 
 func NewPromptPalClient(endpoint string, token string, options PromptPalClientOptions) PromptPalClient {
@@ -52,7 +52,7 @@ func NewPromptPalClient(endpoint string, token string, options PromptPalClientOp
 		endpoint:            endpoint,
 		token:               token,
 		client:              client,
-		applyTemporaryToken: options.applyTemporaryToken,
+		applyTemporaryToken: options.ApplyTemporaryToken,
 	}
 }
 


### PR DESCRIPTION
- Changed applyTemporaryToken field to ApplyTemporaryToken (public) in PromptPalClientOptions
- Updated NewPromptPalClient to use the new public field name
- Users can now set the ApplyTemporaryToken callback when initializing the client

Fixes #13

Generated with [Claude Code](https://claude.ai/code)